### PR TITLE
Add image-based language switcher

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -47,21 +47,20 @@ function initMobileMenu() {
 
 // Language Switcher
 function initLanguageSwitcher() {
-    const languageSelector = document.querySelector('.language-selector');
-    
-    if (languageSelector) {
-        languageSelector.addEventListener('change', function(e) {
-            const selectedLang = e.target.value;
-            
-            // Add loading state
-            e.target.classList.add('loading');
-            
-            // Smooth transition
-            document.body.style.opacity = '0.8';
-            
-            setTimeout(() => {
-                window.location.href = `/language.php?lang=${selectedLang}`;
-            }, 300);
+    const links = document.querySelectorAll('.language-switcher a[data-lang]');
+
+    if (links.length) {
+        links.forEach(link => {
+            link.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selectedLang = this.getAttribute('data-lang');
+
+                document.body.style.opacity = '0.8';
+
+                setTimeout(() => {
+                    window.location.href = `?lang=${selectedLang}`;
+                }, 300);
+            });
         });
     }
 }

--- a/includes/header.php
+++ b/includes/header.php
@@ -54,10 +54,14 @@
                     </ul>
                     
                     <!-- Language Switcher -->
-                    <select class="language-selector form-select ms-3" onchange="window.location.href='?lang='+this.value">
-                        <option value="fr" <?php echo $current_lang == 'fr' ? 'selected' : ''; ?>>Français</option>
-                        <option value="en" <?php echo $current_lang == 'en' ? 'selected' : ''; ?>>English</option>
-                    </select>
+                    <div class="language-switcher ms-3">
+                        <a href="?lang=fr" data-lang="fr" class="<?php echo $current_lang == 'fr' ? 'active' : ''; ?>">
+                            <img src="/assets/images/french.png" alt="Français">
+                        </a>
+                        <a href="?lang=en" data-lang="en" class="<?php echo $current_lang == 'en' ? 'active' : ''; ?>">
+                            <img src="/assets/images/english.png" alt="English">
+                        </a>
+                    </div>
                     
                     <!-- Search Form -->
                     <form class="d-flex ms-3" action="/search" method="get">


### PR DESCRIPTION
## Summary
- use flag icons instead of a dropdown for language selection
- update JavaScript to handle the new switcher

## Testing
- `php -l includes/header.php`

------
https://chatgpt.com/codex/tasks/task_e_687d4476a4fc832497ddf0cf558768b4