### PR TITLE
Add about page translations

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -41,6 +41,30 @@ $translations = [
     'programs' => 'Programs',
     'employment_rate' => 'Employment Rate',
     'campus_view' => 'Campus view',
+
+    // About page
+    'about_us' => 'About Us',
+    'about_description' => <<<'HTML'
+<p>The project to create Burundi Adventist University (BAU) has been in the works for a long time. It was born from the shared inspiration of members and the administration of the Seventh-day Adventist Church both in Burundi and within the East-Central Africa Division. The Church, having been active in education through elementary and secondary schools, now wishes to contribute to the training of Burundian university students, both local and international.</p>
+<p>BAU aims to provide a solid education that enables students to develop intellectually, morally, socially, physically and spiritually for the advancement of themselves, their country of Burundi and the world at large. Opening this university also responds to members of the Adventist Church who, according to their beliefs, cannot study at institutions that hold classes on Saturday.</p>
+<p>The university will operate two campuses: one at Jabe in Mukaza commune, Bwiza zone, and the main campus at Kivoga in Bujumbura province, Mutimbuzi commune. From the outset, BAU plans to be bilingual, using French or English as the language of instruction depending on the course, since these languages are widely used in Africa.</p>
+<p>All lecturers at BAU must use PowerPoint presentations in class and post their notes on Moodle so every student has access. Moodle will also be used to publish assessment results and answer keys, ensuring the consistency of examinations.</p>
+<p>BAU intends to establish both a physical and a virtual library. The physical library will host printed books while the virtual library will provide electronic resources. Students are encouraged to learn typing in their first year so they can prepare their own assignments; typing exercises will be available in the computer lab.</p>
+<p>To maintain quality education, enrollment will be limited to avoid overcrowded classes. Dormitories and a cafeteria will be available on the Kivoga campus, allocated on a first-come, first-served basis.</p>
+<h2>Vision</h2>
+<p>The vision of Burundi Adventist University is to provide high-quality higher education. We aim to make the university a center of excellence where knowledge and skills support transformation and productivity in society. Training will instill integrity, initiative, perseverance and adaptability, enabling students to compete in the job market and assume responsibilities.</p>
+<h2>Mission</h2>
+<ul>
+    <li>Offer holistic and distinctive Christian education that makes students contributors to national development.</li>
+    <li>Develop in students, through study and research, a disposition to dedicate their lives to serving God and humanity with integrity.</li>
+    <li>Prepare students through quality training to face environmental challenges and become agents of positive change, convinced they have something to contribute to humanity.</li>
+    <li>Provide exceptional holistic Christian education—physical, intellectual, moral, social, spiritual and professional—equipping young men and women with skills for quality service.</li>
+</ul>
+<h2>Overall Objective</h2>
+<p>BAU seeks to produce graduates with the expertise, motivation and critical thinking needed to solve problems effectively. The goal is men and women of high integrity who continually pursue excellence and have a clear worldview, ready for service in Burundi and beyond.</p>
+HTML,
+
+    'learn_more' => 'Learn More',
     
     // Footer
     'quick_links' => 'Quick Links',

--- a/languages/fr.php
+++ b/languages/fr.php
@@ -41,6 +41,30 @@ $translations = [
     'programs' => 'Programmes',
     'employment_rate' => 'Taux d\'emploi',
     'campus_view' => 'Vue du campus',
+
+    // Page À propos
+    'about_us' => 'À propos',
+    'about_description' => <<<'HTML'
+<p>Le projet de la création de l’Université Adventiste du Burundi (UAB) ou Burundi Adventist University (BAU) date de longtemps et vient à point nommé. Il est né de l’inspiration conjointe des membres et de l’administration de l’Église Adventiste du 7ᵉ Jour tant au Burundi qu’au niveau de la Division Afrique Centre Est. L’Église, intervenant déjà dans l’éducation fondamentale et post-fondamentale, souhaite contribuer à la formation des étudiants burundais, résidents comme internationaux.</p>
+<p>L’UAB ou BAU, par sa volonté de fournir une éducation solide, donnera aux étudiants les capacités intellectuelles, morales, sociales, physiques et spirituelles nécessaires au développement de leur personne, de leur pays – le Burundi – et du monde en général. L’ouverture de cette université répond aussi aux membres de l’Église Adventiste qui, pour des raisons de foi, ne peuvent étudier dans des institutions dispensant des cours le samedi.</p>
+<p>Deux campus sont prévus : celui de Jabe, dans la commune de Mukaza zone Bwiza, et le campus principal de Kivoga, province Bujumbura, commune Mutimbuzi. Dès le départ, l’UAB/BAU se veut bilingue, utilisant le français ou l’anglais comme langue d’enseignement selon les cours, ces deux langues étant largement employées en Afrique.</p>
+<p>Tous les enseignants devront utiliser des présentations PPT lors des cours magistraux et publier leurs notes sur Moodle afin que chaque étudiant y ait accès. Moodle servira aussi à diffuser les résultats des évaluations ainsi que les corrigés, garantissant la cohérence des épreuves.</p>
+<p>L’université prévoit de mettre en place une bibliothèque physique et virtuelle. La première contiendra des ouvrages papier tandis que la seconde offrira des documents électroniques. Chaque étudiant sera encouragé à apprendre la dactylographie dès la première année pour saisir lui-même ses travaux ; des exercices seront disponibles au laboratoire informatique.</p>
+<p>Dans un souci de qualité, les effectifs seront limités afin d’éviter des classes surchargées. Des internats et une cafétéria seront accessibles sur le campus de Kivoga, les places étant attribuées selon l’ordre d’arrivée et les priorités.</p>
+<h2>Vision</h2>
+<p>La vision de l’Université Adventiste du Burundi est d’être un établissement d’enseignement supérieur de haute qualité. Nous voulons en faire un centre d’excellence dont le développement des connaissances et des aptitudes soutiendra la transformation et la productivité de la société. La formation visera à transmettre aux étudiants le sens de l’intégrité, l’initiative, la persévérance et l’adaptabilité afin de les rendre plus compétitifs sur le marché du travail et capables d’assumer des responsabilités.</p>
+<h2>Mission</h2>
+<ul>
+    <li>Offrir une formation chrétienne intégrale et distinctive faisant des étudiants des acteurs du développement national.</li>
+    <li>Développer chez les étudiants, par l’étude et la recherche, une disposition à consacrer leur vie au service de Dieu et de l’humanité avec intégrité.</li>
+    <li>Préparer l’étudiant par une formation de qualité à relever les défis de son environnement et à devenir un acteur de changement positif, convaincu de sa contribution à l’humanité.</li>
+    <li>S’appliquer à fournir une éducation chrétienne holistique exceptionnelle – physique, intellectuelle, morale, sociale, spirituelle et professionnelle – en transmettant aux jeunes des aptitudes utiles pour un service de qualité.</li>
+</ul>
+<h2>Objectif global</h2>
+<p>L’Université Adventiste du Burundi veut former des diplômés compétents et motivés, dotés d’un esprit critique éclairé et capables de résoudre efficacement les problèmes. L’idéal est de faire d’eux des personnes intègres poursuivant l’excellence avec une vision du monde affirmée, prêtes à servir au Burundi et ailleurs.</p>
+HTML,
+
+    'learn_more' => 'En savoir plus',
     
     // Footer
     'quick_links' => 'Liens rapides',


### PR DESCRIPTION
## Summary
- add English and French About page content
- include link text for Learn More

## Testing
- `php -l languages/en.php`
- `php -l languages/fr.php`
- `php -l modules/about/about.php`


------
https://chatgpt.com/codex/tasks/task_e_687f5e7300308324b94635fbf03934ba